### PR TITLE
re-add finding tEarliest with binary search

### DIFF
--- a/valFuncs/computeOptTraj.m
+++ b/valFuncs/computeOptTraj.m
@@ -78,7 +78,7 @@ while iter <= tauLength
   upper = tauLength;
   lower = tEarliest;
   
-  tEarliest = lower; %find_earliest_BRS_ind(g, data, dynSys.x, upper, lower);
+  tEarliest = find_earliest_BRS_ind(g, data, dynSys.x, upper, lower);
    
   % BRS at current time
   BRS_at_t = data(clns{:}, tEarliest);


### PR DESCRIPTION
When testing chaning `tMax` in `tutorial.m`, we found that the DubinsCar model would not go to the target set.


https://user-images.githubusercontent.com/26592062/124532129-c433f500-ddc4-11eb-9f2b-9d945d082b73.mov

https://user-images.githubusercontent.com/26592062/124532140-c6964f00-ddc4-11eb-9920-c8c6998feada.mov





- fix issue where computing optimal trajectory for long durations
  would not result in player reaching target set since tEarliest would
  not update